### PR TITLE
feat: Add .prettierrc configuration file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "es5",
+  "printWidth": 80,
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf",
+  "proseWrap": "preserve"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -8,5 +8,10 @@
   "bracketSpacing": true,
   "arrowParens": "avoid",
   "endOfLine": "lf",
-  "proseWrap": "preserve"
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": true,
+  "bracketSameLine": false,
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "embeddedLanguageFormatting": "auto"
 }


### PR DESCRIPTION
Closes #60

## Summary
Added a .prettierrc configuration file to standardize code formatting for JSON, YAML, Markdown, and other supported file types in the project.

## Configuration Details
- Uses 2-space indentation
- Single quotes preferred
- 80 character line width
- No trailing semicolons
- LF line endings
- ES5 trailing commas

## Test Plan
- [x] Added .prettierrc configuration file
- [x] Verified file is properly formatted JSON
- [x] No impact on existing Python code

🤖 Generated with [Claude Code](https://claude.com/claude-code)